### PR TITLE
fix: :bug: Fixed the error (Typescript: Type 'string' is not assignab…

### DIFF
--- a/src/components/magicui/blur-fade.tsx
+++ b/src/components/magicui/blur-fade.tsx
@@ -29,7 +29,10 @@ const BlurFade = ({
   blur = "6px",
 }: BlurFadeProps) => {
   const ref = useRef(null);
-  const inViewResult = useInView(ref, { once: true, margin: inViewMargin });
+  const inViewResult = useInView(ref, {
+    once: true,
+    margin: `${Number(inViewMargin)}px`,
+  });
   const isInView = !inView || inViewResult;
   const defaultVariants: Variants = {
     hidden: { y: yOffset, opacity: 0, filter: `blur(${blur})` },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bb481c55-860a-4c94-89dc-530b6ff18d12)

I would have preferred to implement it directly in BlurFadeProps, but unfortunately, MarginType isn't considered a public type.

![image](https://github.com/user-attachments/assets/58e77340-02b7-4ec5-be6e-83bed97d6dbb)
