### PR TITLE
Fix docker tooltip to show correct social name

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -54,7 +54,7 @@ export default function Navbar() {
                   </Link>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{name}</p>
+                  <p>{social.name}</p>
                 </TooltipContent>
               </Tooltip>
             </DockIcon>


### PR DESCRIPTION
Updated the tooltip to display `{social.name}` instead of `{name}`. This ensures the correct name is shown for each social icon.