### PR TITLE
fix: type error for inViewMargin

### DIFF
--- a/src/components/magicui/blur-fade.tsx
+++ b/src/components/magicui/blur-fade.tsx
@@ -2,6 +2,9 @@
 
 import { AnimatePresence, motion, useInView, Variants } from "framer-motion";
 import { useRef } from "react";
+type MarginValue = `${number}${'px' | '%'}`;
+type MarginType = MarginValue | `${MarginValue} ${MarginValue}` | `${MarginValue} ${MarginValue} ${MarginValue}` | `${MarginValue} ${MarginValue} ${MarginValue} ${MarginValue}`;
+
 
 interface BlurFadeProps {
   children: React.ReactNode;
@@ -14,7 +17,7 @@ interface BlurFadeProps {
   delay?: number;
   yOffset?: number;
   inView?: boolean;
-  inViewMargin?: string;
+  inViewMargin?: MarginType;
   blur?: string;
 }
 const BlurFade = ({


### PR DESCRIPTION
This fixes a linting error building the site as static site:

   Linting and checking validity of types  ...Failed to compile.

./src/components/magicui/blur-fade.tsx:32:53
Type error: Type 'string' is not assignable to type 'MarginType | undefined'.

  30 | }: BlurFadeProps) => {
  31 |   const ref = useRef(null);
> 32 |   const inViewResult = useInView(ref, { once: true, margin: inViewMargin });
     |                                                     ^
  33 |   const isInView = !inView || inViewResult;
  34 |   const defaultVariants: Variants = {
  35 |     hidden: { y: yOffset, opacity: 0, filter: `blur(${blur})` },
 ELIFECYCLE  Command failed with exit code 1.