### PR TITLE
fix: resolve type error in BlurFade component for inView margin prop

### DIFF
--- a/src/components/magicui/blur-fade.tsx
+++ b/src/components/magicui/blur-fade.tsx
@@ -29,7 +29,7 @@ const BlurFade = ({
   blur = "6px",
 }: BlurFadeProps) => {
   const ref = useRef(null);
-  const inViewResult = useInView(ref, { once: true, margin: inViewMargin });
+  const inViewResult = useInView(ref, { once: true, margin: inViewMargin as any });
   const isInView = !inView || inViewResult;
   const defaultVariants: Variants = {
     hidden: { y: yOffset, opacity: 0, filter: `blur(${blur})` },


### PR DESCRIPTION
- Updated `BlurFade` component by casting `inViewMargin` to `any` when passed to `useInView`, bypassing strict typing issues with `framer-motion`.
- This change ensures compatibility with custom string values for the margin parameter, preventing TypeScript errors while maintaining the intended blur and fade effects.