### PR TITLE
added a minimal credit section, commented out

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,6 +220,19 @@ export default function Page() {
           </BlurFade>
         </div>
       </section>
+      {/* <section id="credit">
+        <div className="w-full text-center text-xs text-muted-foreground">
+          Credit to{" "}
+          <a
+            href="https://x.com/dillionverma"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            @dillion
+          </a>{" "}
+          for the sick website template!
+        </div>
+      </section> */}
     </main>
   );
 }


### PR DESCRIPTION
Wanted a way to give credit to this sick template and didn't see one included, so I thought I would make a PR with what I did but commented out, so people can easily uncomment to give credit if they want.

<img width="1042" alt="Screenshot 2024-11-27 at 2 01 46 PM" src="https://github.com/user-attachments/assets/74992b9d-7b50-4941-b56d-4c9fc06bad81">
